### PR TITLE
Missing email icon

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ CHANGELOG
 1.2.5 (unreleased)
 ------------------
 
+- Removed broken image in ads view.
+  [Julian Infanger]
+
 - Implement billboard conditions.
   [mathias.leimgruber]
 

--- a/ftw/billboard/browser/ad.pt
+++ b/ftw/billboard/browser/ad.pt
@@ -80,7 +80,6 @@
                     <tr>
                         <th i18n:translate="">Contact</th>
                         <td>
-                            <img tal:attributes="src string:${portal_url}/mail_icon.gif" alt="" />
                             <a tal:define="mail context/getContactMail"
                                tal:attributes="href string:mailto:${mail}" tal:content="mail" />
                         </td>


### PR DESCRIPTION
In teamraum 4.1
![bildschirmfoto 2013-11-05 um 10 36 25](https://f.cloud.github.com/assets/157533/1472256/20a75c8a-45fe-11e3-8ddd-f75a86dd6c0a.png)
