### PR TITLE
Include the Products.CMFCore package

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ CHANGELOG
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Include the Products.CMFCore package to be sure the cmf.ModifyPortalContent
+  permission is loaded before used
+  [elioschmutz]
 
 
 1.5.0 (2015-09-21)

--- a/ftw/billboard/configure.zcml
+++ b/ftw/billboard/configure.zcml
@@ -12,6 +12,8 @@
 
     <i18n:registerTranslations directory="locales" />
 
+    <include package="Products.CMFCore" />
+
     <!-- Include the sub-packages that use their own configure.zcml files. -->
     <include package="ftw.colorbox" />
     <include package="ftw.profilehook" />

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(name='ftw.billboard',
       zip_safe=False,
 
       install_requires=[
-        'Plone',  
+        'Plone',
+        'Products.CMFCore',
         'ftw.calendarwidget',
         'ftw.colorbox',
         'ftw.lawgiver',


### PR DESCRIPTION
Include the Products.CMFCore package to be sure the cmf.ModifyPortalContent permission is loaded before used