### PR TITLE
Drop Plone 4.1 support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ CHANGELOG
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop Plone 4.1 support. [jone]
 
 
 1.5.2 (2016-10-03)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(name='ftw.billboard',
       # http://www.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Framework :: Zope2',

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-
-package-name = ftw.billboard


### PR DESCRIPTION
Tests are failing, we are no longer supporting Plone 4.1.