### PR TITLE
Add uninstall profile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ CHANGELOG
 ------------------
 
 - Drop Plone 4.1 support. [jone]
+- Drop Plone 4.2 support. [mathias.leimgruber]
 - Add uninstall profile. [mathias.leimgruber]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ CHANGELOG
 ------------------
 
 - Drop Plone 4.1 support. [jone]
+- Add uninstall profile. [mathias.leimgruber]
 
 
 1.5.2 (2016-10-03)

--- a/ftw/billboard/Extensions/install.py
+++ b/ftw/billboard/Extensions/install.py
@@ -1,0 +1,8 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def uninstall(self):
+    setup_tool = getToolByName(self, 'portal_setup')
+    setup_tool.runAllImportStepsFromProfile(
+        'profile-ftw.billboard:uninstall',
+        ignore_dependencies=True)

--- a/ftw/billboard/configure.zcml
+++ b/ftw/billboard/configure.zcml
@@ -34,6 +34,15 @@
         description=""
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
+
+    <genericsetup:registerProfile
+        name="uninstall"
+        title="ftw.billboard : uninstall"
+        directory="profiles/uninstall"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        />
+
     <include package=".upgrades" />
 
     <profilehook:hook
@@ -41,4 +50,8 @@
         handler=".hooks.imported"
         />
 
+    <profilehook:hook
+        profile="ftw.billboard:uninstall"
+        handler=".hooks.uninstalled"
+        />
 </configure>

--- a/ftw/billboard/hooks.py
+++ b/ftw/billboard/hooks.py
@@ -29,3 +29,16 @@ def add_catalog_indexes(portal, INDEXES):
     if len(indexables) > 0:
         logger.info("Indexing new indexes %s.", ', '.join(indexables))
         catalog.manage_reindexIndex(ids=indexables)
+
+
+def uninstalled(portal):
+    remove_catalog_indexes(portal)
+
+
+def remove_catalog_indexes(portal):
+    catalog = portal.portal_catalog
+    indexes = catalog.indexes()
+
+    for name, meta_type in INDEXES:
+        if name in indexes:
+            catalog.delIndex(name)

--- a/ftw/billboard/profiles/uninstall/catalog.xml
+++ b/ftw/billboard/profiles/uninstall/catalog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_catalog" meta_type="Plone Catalog Tool">
+
+        <column value="getAdExpirationDate" remove="True"/>
+
+</object>

--- a/ftw/billboard/profiles/uninstall/factorytool.xml
+++ b/ftw/billboard/profiles/uninstall/factorytool.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_factory" meta_type="Plone Factory Tool">
+  <factorytypes>
+    <type portal_type="BillboardAd" remove="True"/>
+    <type portal_type="BillboardCategory" remove="True"/>
+  </factorytypes>
+</object>

--- a/ftw/billboard/profiles/uninstall/portlets.xml
+++ b/ftw/billboard/profiles/uninstall/portlets.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<portlets xmlns:i18n="http://namespaces.zope.org/i18n"
+          i18n:domain="plone">
+    <portlet
+      addview="billboard.actions.portlet"
+      title="billboard actions portlet"
+      description="display add/edid/del actions" remove="True">
+    </portlet>
+    
+    <assignment 
+        name="billboard-actions"
+        category="content_type"
+        key="BillboardCategory"
+        manager="plone.rightcolumn"
+        type="ftw.billboard.portlets.actions"
+        remove="True"
+    />
+    <assignment
+        name="billboard-actions"
+        category="content_type"
+        key="BillboardAd"
+        manager="plone.rightcolumn"
+        type="ftw.billboard.portlets.actions"
+        remove="True"
+    />
+</portlets>

--- a/ftw/billboard/profiles/uninstall/registry.xml
+++ b/ftw/billboard/profiles/uninstall/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+    <record name="ftw.billboard.days_to_expire" remove="True" />
+    <record name="ftw.billboard.currency" remove="True" />
+    <record name="ftw.billboard.decimalmark" remove="True" />
+    <record name="ftw.billboard.thousandsseparator" remove="True" />
+</registry>

--- a/ftw/billboard/profiles/uninstall/rolemap.xml
+++ b/ftw/billboard/profiles/uninstall/rolemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.billboard: Add BillboardAd" acquire="True">
+    </permission>
+    <permission name="ftw.billboard: Add BillboardCategory" acquire="True">
+    </permission>
+  </permissions>
+</rolemap>

--- a/ftw/billboard/profiles/uninstall/types.xml
+++ b/ftw/billboard/profiles/uninstall/types.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+    <object name="BillboardAd" remove="True"/>
+    <object name="BillboardCategory" remove="True"/>
+</object>

--- a/ftw/billboard/tests/test_uninstall.py
+++ b/ftw/billboard/tests/test_uninstall.py
@@ -1,0 +1,8 @@
+from ftw.testing.genericsetup import GenericSetupUninstallMixin
+from ftw.testing.genericsetup import apply_generic_setup_layer
+from unittest2 import TestCase
+
+
+@apply_generic_setup_layer
+class TestGenericSetupUninstall(TestCase, GenericSetupUninstallMixin):
+    package = 'ftw.billboard'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(name='ftw.billboard',
       # http://www.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Framework :: Zope2',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = [
     'plone.app.testing',
     'ftw.builder',
     'ftw.testbrowser',
+    'ftw.testing',
     'unittest2',
     ]
 

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-
-package-name = ftw.billboard


### PR DESCRIPTION
Created instances of this package are not handled in the uninstall profile on purpose.
Getting rid of data is the integrators job. 

Please run tests locally, the webhook is not triggered. 

Here my local output:
```
(plone) maethu|[mle-uninstall]%> ./bin/test
Running ftw.billboard.testing.FtwBillboard:Integration tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.174 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.615 seconds.
  Set up ftw.builder.testing.BuilderLayer in 0.000 seconds.
  Set up ftw.billboard.testing.FtwBillboardLayer in 1.713 seconds.
  Set up ftw.billboard.testing.FtwBillboard:Integration in 0.000 seconds.
  Running:

  Ran 4 tests with 0 failures, 0 errors, 0 skipped in 0.328 seconds.
Running ftw.billboard.testing.ftw.billboard:functional tests:
  Tear down ftw.billboard.testing.FtwBillboard:Integration in 0.000 seconds.
  Set up ftw.builder.testing.set_builder_session_factory in 0.000 seconds.
  Set up ftw.billboard.testing.ftw.billboard:functional in 0.000 seconds.
  Running:

  Ran 9 tests with 0 failures, 0 errors, 0 skipped in 5.343 seconds.
Running ftw.testing.genericsetup.genericsetup-uninstall:TestGenericSetupUninstall tests:
  Tear down ftw.billboard.testing.ftw.billboard:functional in 0.000 seconds.
  Tear down ftw.builder.testing.set_builder_session_factory in 0.000 seconds.
  Tear down ftw.billboard.testing.FtwBillboardLayer in 0.004 seconds.
  Tear down ftw.builder.testing.BuilderLayer in 0.000 seconds.
  Set up ftw.testing.genericsetup.ZCMLLayer in 0.861 seconds.
  Set up ftw.testing.genericsetup.genericsetup-uninstall:TestGenericSetupUninstall in 0.000 seconds.
  Running:

  Ran 3 tests with 0 failures, 0 errors, 0 skipped in 3.980 seconds.
Running zope.testrunner.layer.UnitTests tests:
  Tear down ftw.testing.genericsetup.genericsetup-uninstall:TestGenericSetupUninstall in 0.000 seconds.
  Tear down ftw.testing.genericsetup.ZCMLLayer in 0.004 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.120 seconds.
  Tear down plone.testing.z2.Startup in 0.007 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.005 seconds.
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:

  Ran 6 tests with 0 failures, 0 errors, 0 skipped in 0.001 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
Total: 22 tests, 0 failures, 0 errors, 0 skipped in 20.545 seconds
```